### PR TITLE
Fix Logger histogram flag usage

### DIFF
--- a/src/pysim/utils.py
+++ b/src/pysim/utils.py
@@ -297,7 +297,20 @@ class Logger:
             self.episode_ended = True
 
     def add_metric(self, tag, value, hist=False):
-        self.histograms[tag].append(value)
+        """Add a metric for logging.
+
+        Parameters
+        ----------
+        tag : str
+            Name of the metric.
+        value : Any
+            Value to log.
+        hist : bool, optional
+            If True, store the value for histogram logging. If False, the value
+            will only be tracked as a scalar metric. Defaults to False.
+        """
+        if hist:
+            self.histograms[tag].append(value)
         self.metrics[tag].append(value)
 
     def log_scalar(self, tag, value, step: int = None):


### PR DESCRIPTION
## Summary
- respect `hist` flag in `Logger.add_metric`
- document parameters for logging helper

## Testing
- `python -m py_compile src/pysim/utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895c9bdfa9c8321a34c47a5b1d07749