### PR TITLE
Optimize FireCell random generator usage

### DIFF
--- a/src/firespin/firemodel_firecell.cpp
+++ b/src/firespin/firemodel_firecell.cpp
@@ -34,10 +34,7 @@ FireCell::FireCell(int x, int y, std::mt19937& gen, FireModelParameters &paramet
         tau_ign_ = cell_->GetIgnitionDelayTime();
     }
 
-    // TODO Auslagern der Zufallszahlen in eine eigene Klasse?
     // Initialize random number generator
-    std::random_device rd;
-    gen_.seed(rd());
     real_dis_ = std::uniform_real_distribution<>(0.0, 1.0);
     std::uniform_real_distribution<> dis(0.1, 0.2);
     std::uniform_int_distribution<> sign_dis(-1, 1);
@@ -332,9 +329,10 @@ void FireCell::GenerateNoiseMap() {
     int noise_level = cell_->GetNoiseLevel();
     int size = cell_->GetNoiseSize();
     noise_map_.resize(size, std::vector<int>(size));
+    std::uniform_int_distribution<> dist(-noise_level, noise_level);
     for (int y = 0; y < size; ++y) {
         for (int x = 0; x < size; ++x) {
-            noise_map_[y][x] = std::rand() % (2 * noise_level) - noise_level;
+            noise_map_[y][x] = dist(gen_);
         }
     }
 }

--- a/src/firespin/firemodel_firecell.h
+++ b/src/firespin/firemodel_firecell.h
@@ -99,7 +99,7 @@ private:
     std::vector<std::vector<int>> noise_map_;
 
     // Random Generator for the particles
-    std::mt19937 gen_;
+    std::mt19937& gen_;
     std::uniform_real_distribution<> real_dis_;
 
     ICell *GetCell();


### PR DESCRIPTION
## Summary
- avoid reseeding per-cell random generator
- replace rand() calls with distribution using shared RNG

## Testing
- `cmake ..` *(fails: Could not find SDL2)*
- `g++ -std=c++17 -Isrc -I../src -c ../src/firespin/firemodel_firecell.cpp` *(fails: src/utils.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895cc0545708321a65752adbf978dad