### PR TITLE
Refactor PPO advantage computation

### DIFF
--- a/src/pysim/algorithms/ppo.py
+++ b/src/pysim/algorithms/ppo.py
@@ -130,14 +130,17 @@ class PPO(RLAlgorithm):
             if masks[i] == 1:
                 delta = delta + self.gamma * values[i + 1]
             gae = delta + self.gamma * self._lambda * masks[i] * gae
-            advantages.insert(0, gae)
-            returns.insert(0, gae + values[i])
+            advantages.append(gae)
+            returns.append(gae + values[i])
+
+        # Reverse to restore original order
+        advantages = torch.FloatTensor(list(reversed(advantages))).to(self.device)
+        returns = torch.FloatTensor(list(reversed(returns))).to(self.device)
 
         # Norm advantages
-        advantages = torch.FloatTensor(advantages).to(self.device)
         advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-10)
 
-        return advantages, torch.FloatTensor(returns).to(self.device)
+        return advantages, returns
 
     @staticmethod
     def calculate_explained_variance(values, returns):


### PR DESCRIPTION
## Summary
- use append and reversed order to accumulate advantages and returns
- normalize advantages after restoring original ordering

## Testing
- `python -m pytest`
- `python -m py_compile src/pysim/algorithms/ppo.py`


------
https://chatgpt.com/codex/tasks/task_e_6895d2420b70832195affcc54ea91c9e