### PR TITLE
feat: add env flag for torch anomaly detection

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ settings:
   llm_support: false # Whether to use LLM support for the environment (currently not supported)
   hierarchy_type: planner_agent # Type of hierarchy to use for the agents (fly_agent, explore_agent, planner_agent)
   skip_gui_init: true # Uses this config as default and skips the GUI setup
+  pytorch_detect_anomaly: true # Enable PyTorch autograd anomaly detection
   auto_train:
     use_auto_train: false # Whether to use auto training
     train_episodes: 3 # Number of total trainings, each containing max_train train_steps

--- a/src/pysim/main.py
+++ b/src/pysim/main.py
@@ -21,7 +21,6 @@ if pythonversion != firesimverison:
                      f"Activate your conda environment before compiling the library.")
 
 import firesim
-from hierarchy_manager import HierarchyManager
 
 def assert_config(config):
     """
@@ -47,6 +46,11 @@ def main(config_path_ : str = ""):
         config = yaml.safe_load(f)
 
     assert_config(config)
+
+    if config["settings"].get("pytorch_detect_anomaly"):
+        os.environ["PYTORCH_DETECT_ANOMALY"] = "true"
+
+    from hierarchy_manager import HierarchyManager
 
     logging.basicConfig(
         level=logging.DEBUG,

--- a/src/pysim/networks/network_explore.py
+++ b/src/pysim/networks/network_explore.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import torch.nn as nn
 import torch.nn.functional as F
@@ -6,7 +7,8 @@ import torch
 from networks.network_fly import DeterministicActor
 from utils import initialize_output_weights, get_in_features_2d, get_in_features_3d
 
-torch.autograd.set_detect_anomaly(True)
+if os.getenv("PYTORCH_DETECT_ANOMALY", "").lower() in ("1", "true"):
+    torch.autograd.set_detect_anomaly(True)
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 

--- a/src/pysim/networks/network_fly.py
+++ b/src/pysim/networks/network_fly.py
@@ -1,10 +1,12 @@
+import os
 import numpy as np
 import torch.nn as nn
 import torch.nn.functional as F
 import torch
 from utils import initialize_output_weights, get_in_features_2d, get_in_features_3d
 
-torch.autograd.set_detect_anomaly(True)
+if os.getenv("PYTORCH_DETECT_ANOMALY", "").lower() in ("1", "true"):
+    torch.autograd.set_detect_anomaly(True)
 
 class Inputspace(nn.Module):
 

--- a/src/pysim/networks/network_planner.py
+++ b/src/pysim/networks/network_planner.py
@@ -1,10 +1,12 @@
+import os
 import numpy as np
 import torch.nn as nn
 import torch.nn.functional as F
 import torch
 from utils import initialize_output_weights, get_in_features_2d, get_in_features_3d
 
-torch.autograd.set_detect_anomaly(True)
+if os.getenv("PYTORCH_DETECT_ANOMALY", "").lower() in ("1", "true"):
+    torch.autograd.set_detect_anomaly(True)
 
 class Inputspace(nn.Module):
 


### PR DESCRIPTION
## Summary
- make PyTorch anomaly detection optional via `PYTORCH_DETECT_ANOMALY`
- wire optional anomaly detection into fly, explore and planner networks
- enable anomaly detection in default config and set env var during startup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895d534a8ac8321876f6178bd220455