### PR TITLE
Refactor explore agent data restructuring

### DIFF
--- a/src/pysim/explore_agent.py
+++ b/src/pysim/explore_agent.py
@@ -61,24 +61,27 @@ class ExploreAgent(Agent):
 
     @staticmethod
     def restructure_data(observations_):
-        #all_explore_maps, all_total_views = [], []
-        all_explore_maps, all_positions = [], []
-
         obs = observations_["explore_agent"]
-        for deque in obs:
-            drone_states = np.array([state for state in deque if isinstance(state, firesim.AgentState)])
-            if len(drone_states) == 0:
-                continue
 
-            #multi_total_drone_view = np.array([state.GetMultipleTotalDroneView() for state in drone_states])
-            exploration_map = np.array([state.GetExplorationMapNorm() for state in drone_states])
-            positions = [np.array([state.GetGridPositionDoubleNorm() for state in drone_states])]
+        drone_state_groups = [
+            [state for state in deque if isinstance(state, firesim.AgentState)]
+            for deque in obs
+        ]
+        drone_state_groups = [group for group in drone_state_groups if group]
 
-            all_explore_maps.append(exploration_map)
-            all_positions.append(positions)
+        if not drone_state_groups:
+            raise ValueError("No AgentState data found in observations for explore_agent")
 
-        all_explore_maps = np.array(all_explore_maps)
-        all_positions = np.array(all_positions)
+        exploration_maps = [
+            [state.GetExplorationMapNorm() for state in group]
+            for group in drone_state_groups
+        ]
+        positions = [
+            [state.GetGridPositionDoubleNorm() for state in group]
+            for group in drone_state_groups
+        ]
+
+        all_explore_maps = np.stack(exploration_maps)
+        all_positions = np.stack(positions)
 
         return all_positions, all_explore_maps
-        #return np.transpose(np.array(all_total_views), (0,2,1,3,4)), all_explore_maps


### PR DESCRIPTION
## Summary
- simplify restructure_data in ExploreAgent by using list comprehensions and a single np.stack
- avoid per-element numpy array creation for GetGridPositionDoubleNorm
- guard against empty AgentState groups by raising a clear ValueError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895e894e9108321ab56fd330dae852b