### PR TITLE
Persist visited cell buffer

### DIFF
--- a/src/firespin/firemodel_gridmap.h
+++ b/src/firespin/firemodel_gridmap.h
@@ -143,6 +143,7 @@ private:
     std::vector<std::vector<int>> explored_map_;
     std::vector<std::vector<int>> step_explored_map_;
     std::vector<std::vector<int>> fire_map_;
+    std::vector<std::vector<bool>> visited_cells_;
     std::unordered_set<Point> ticking_cells_;
     std::unordered_set<Point> burning_cells_;
     std::unordered_set<Point> flooded_cells_;


### PR DESCRIPTION
## Summary
- Add persistent `visited_cells_` matrix to `GridMap` and initialize it once
- Reset `visited_cells_` with `std::fill` in `UpdateParticles` to reuse buffer
- Clear `visited_cells_` in destructor to avoid lingering state

## Testing
- `g++ -std=c++17 -I src -I src/firespin -I src/reinforcementlearning -c src/firespin/firemodel_gridmap.cpp -fopenmp` *(fails: json.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895f4d8a2088321bb22255d14b10e7b